### PR TITLE
remove outdated node.js warning by using latest dependent actions

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,21 +1,46 @@
 name: Publish GitHub Pages
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   publish:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Convert Markdown into HTML and PDF
-        uses: KoharaKazuya/marp-cli-action@v3
+        uses: KoharaKazuya/marp-cli-action@v2
+#        with:
+#          config-file: ./.marprc.yml
+#          generate-pptx: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Convert Markdown into HTML and PDF
         uses: KoharaKazuya/marp-cli-action@v2
+# to enable html option, modify .marprc.yml and uncomment below
+# to enable pptx generation, uncomment below
 #        with:
 #          config-file: ./.marprc.yml
 #          generate-pptx: true

--- a/.marprc.yml
+++ b/.marprc.yml
@@ -1,0 +1,2 @@
+allowLocalFiles: true
+html: true


### PR DESCRIPTION
* remove outdated node.js warning by using latest dependent actions
* use actions/upload-pages-artifact@v3 instead peaceiris/actions-gh-pages@v3
* add .marprc.yml and commented usage help string for it in the publish.yml